### PR TITLE
Deprecated workaround

### DIFF
--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -12,6 +12,9 @@ jobs:
   merge-checks:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[skip checks]')"
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -17,3 +17,5 @@ jobs:
 
       - name: Merge checks
         uses: moneymeets/action-merge-checks@master
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Merge checks
         uses: moneymeets/action-merge-checks@master
         with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[skip checks]')"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Merge checks
         uses: moneymeets/action-merge-checks@master

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,35 @@
+# This file was added by Pulumi and should not be edited manually. To edit the contents of this file, please go
+# to the github-management project in moneymeets-pulumi and call `pulumi up` after changing the template file.
+
+name: Rebase
+
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  rebase:
+    # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
+    if: github.event.issue.pull_request && github.event.comment.body == '/rebase'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+          token: ${{ secrets.WORKFLOW_GITHUB_ACCESS_TOKEN }}
+
+      - name: Checkout PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          hub pr checkout ${{ github.event.issue.number }}
+
+      - name: Rebase and push
+        run: |
+          git config user.name 'Sir Mergealot'
+          git config user.email 'mergealot@moneymeets.com'
+
+          GIT_SEQUENCE_EDITOR=true git rebase --interactive --autosquash origin/master
+
+          git push -u origin HEAD --force-with-lease

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
-          token: ${{ secrets.WORKFLOW_GITHUB_ACCESS_TOKEN }}
+          ssh-key: '${{ secrets.WORKFLOW_DEPLOY_KEY }}'
 
       - name: Checkout PR
         env:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ heroku config:set PYTHON_RUNTIME_VERSION=3.9.1
 Poetry version can be specified by setting `POETRY_VERSION` in Heroku config vars. Otherwise, it will default to a hardcoded version.
 
 ```
-heroku config:set POETRY_VERSION=1.1.12
+heroku config:set POETRY_VERSION=1.1.13
 ```
 
 Generally all variables starting with `POETRY_` are passed on to Poetry by this buildpack; see the corresponding [Poetry documentation](https://python-poetry.org/docs/configuration/#using-environment-variables) section for possible uses.

--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,9 @@ curl -sSL https://install.python-poetry.org \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent
+    
+echo 'Adding poetry to the $PATH'
+export PATH="/app/.local/bin:$PATH"
 
 PATH_TO_POETRY_ENV="$HOME/.poetry/env"
 

--- a/bin/compile
+++ b/bin/compile
@@ -44,13 +44,6 @@ curl -sSL https://install.python-poetry.org \
 echo 'Adding poetry to the $PATH'
 export PATH="/app/.local/bin:$PATH"
 
-# PATH_TO_POETRY_ENV="$HOME/.poetry/env"
-
-# if [ -f "$PATH_TO_POETRY_ENV" ] ; then
-#     # shellcheck source=/dev/null
-#     . "$PATH_TO_POETRY_ENV"
-# fi
-
 REQUIREMENTS_FILE="requirements.txt"
 
 log "Export $REQUIREMENTS_FILE from Poetry"

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ curl -sSL https://install.python-poetry.org \
     | python3 \
     | indent
     
-echo 'Adding poetry to the $PATH'
+log 'Adding poetry to the $PATH'
 export PATH="/app/.local/bin:$PATH"
 
 REQUIREMENTS_FILE="requirements.txt"

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ curl -sSL https://install.python-poetry.org \
     | python3 \
     | indent
     
-log 'Adding poetry to the $PATH'
+log "Adding poetry to the PATH"
 export PATH="/app/.local/bin:$PATH"
 
 REQUIREMENTS_FILE="requirements.txt"

--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ log "Generate requirements.txt with Poetry"
 
 log "Install Poetry"
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
+curl -sSL https://install.python-poetry.org \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent

--- a/bin/compile
+++ b/bin/compile
@@ -57,7 +57,7 @@ log "Export $REQUIREMENTS_FILE from Poetry"
 
 cd "$BUILD_DIR"
 
-EXPORT_PARAMETERS=(--without-hashes --with-credentials --quiet)
+EXPORT_PARAMETERS=(--without-hashes --with-credentials)
 
 if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     log "Enable exporting dev requirements to $REQUIREMENTS_FILE"
@@ -66,10 +66,8 @@ fi
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
-poetry export -f "$REQUIREMENTS_FILE" "${EXPORT_PARAMETERS[@]}" > "$REQUIREMENTS_FILE.orig"
+poetry export -f requirements.txt "${EXPORT_PARAMETERS[@]}" -o "$REQUIREMENTS_FILE.orig"
 sed -e 's/^-e //' < "$REQUIREMENTS_FILE.orig" > "$REQUIREMENTS_FILE" && rm "$REQUIREMENTS_FILE.orig"
-
-cat "$REQUIREMENTS_FILE"
 
 RUNTIME_FILE="runtime.txt"
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ for env_file in $BUILDPACK_VARIABLES ; do
 done
 
 if [ -z "${POETRY_VERSION:-}" ] ; then
-    export POETRY_VERSION=1.1.12
+    export POETRY_VERSION=1.1.13
     log "No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
 else
     log "Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"

--- a/bin/compile
+++ b/bin/compile
@@ -44,12 +44,12 @@ curl -sSL https://install.python-poetry.org \
 echo 'Adding poetry to the $PATH'
 export PATH="/app/.local/bin:$PATH"
 
-PATH_TO_POETRY_ENV="$HOME/.poetry/env"
+# PATH_TO_POETRY_ENV="$HOME/.poetry/env"
 
-if [ -f "$PATH_TO_POETRY_ENV" ] ; then
-    # shellcheck source=/dev/null
-    . "$PATH_TO_POETRY_ENV"
-fi
+# if [ -f "$PATH_TO_POETRY_ENV" ] ; then
+#     # shellcheck source=/dev/null
+#     . "$PATH_TO_POETRY_ENV"
+# fi
 
 REQUIREMENTS_FILE="requirements.txt"
 
@@ -68,6 +68,8 @@ fi
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
 poetry export -f "$REQUIREMENTS_FILE" "${EXPORT_PARAMETERS[@]}" > "$REQUIREMENTS_FILE.orig"
 sed -e 's/^-e //' < "$REQUIREMENTS_FILE.orig" > "$REQUIREMENTS_FILE" && rm "$REQUIREMENTS_FILE.orig"
+
+cat "$REQUIREMENTS_FILE"
 
 RUNTIME_FILE="runtime.txt"
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ for env_file in $BUILDPACK_VARIABLES ; do
 done
 
 if [ -z "${POETRY_VERSION:-}" ] ; then
-    export POETRY_VERSION=1.1.13
+    export POETRY_VERSION=1.2.0
     log "No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
 else
     log "Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"

--- a/bin/compile
+++ b/bin/compile
@@ -57,7 +57,7 @@ log "Export $REQUIREMENTS_FILE from Poetry"
 
 cd "$BUILD_DIR"
 
-EXPORT_PARAMETERS=(--without-hashes --with-credentials)
+EXPORT_PARAMETERS=(--without-hashes --with-credentials --quiet)
 
 if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     log "Enable exporting dev requirements to $REQUIREMENTS_FILE"

--- a/test/fixtures/compile-export_dev.stdout.txt
+++ b/test/fixtures/compile-export_dev.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.12.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-force_python_version.stdout.txt
+++ b/test/fixtures/compile-force_python_version.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.12.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-invalid_python_version.stdout.txt
+++ b/test/fixtures/compile-invalid_python_version.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.12.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-no_vars_success.stdout.txt
+++ b/test/fixtures/compile-no_vars_success.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.12.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-skip_runtime_error.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_error.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.12.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-skip_runtime_success.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_success.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.12.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<


### PR DESCRIPTION
DO NOT MERGE

This branch freezes a fix for the broken buildpack in heroku so we can reliably reference it in our environment

Once this PR on the upstream moneymeets we can switch back to the canonical version if we want to: https://github.com/moneymeets/python-poetry-buildpack/pull/44